### PR TITLE
fix(builder): fix ./reconfigure file update step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,3 @@
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install libpam-dev
-    - sudo apt-get install libssl-dev
-    - sudo apt-get install libpcap-dev
-
-notifications:
-    webhooks:
-      urls:
-        - https://webhooks.gitter.im/e/99792de66d1b43ebb54d
-      on_success: change
-      on_failure: always
-      on_start: false
-
 language: python
 
 python:
@@ -19,8 +5,24 @@ python:
     - "2.7"
 
 env:
-    - CC=gcc
-    - CC=clang
+    - CC=gcc   ARCH=x86
+    - CC=gcc   ARCH=x64
+    - CC=clang ARCH=x86
+    - CC=clang ARCH=x64
+
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install libpam-dev
+    - sudo apt-get install libssl-dev
+    - sudo apt-get install libpcap-dev
 
 script:
-    ./utils/run-tests.sh tests
+    make test
+
+notification:
+    webhooks:
+      urls:
+        - https://webhooks.gitter.im/e/99792de66d1b43ebb54d
+      on_success: change
+      on_failure: always
+      on_start: false

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 
 # run all tests with `make test`
 test:
-	./utils/run-tests.sh ./tests
+	./utils/run-tests.sh tests
 
 # compile DSO with flags for code coverage
 coverage:

--- a/reconfigure
+++ b/reconfigure
@@ -30,7 +30,7 @@ def fatal_error(msg):
     it means that something is missing in builder's code
     and something MUST be patched
     """
-    sys.exit("[BUILDER FATAL ERROR]: %s" % msg)
+    sys.exit("%s: fatal error: %s" % (sys.argv[0], msg))
 
 if len(sys.argv) != 2:
     help()
@@ -310,14 +310,6 @@ CONFIG_C %= {
         "literals": "\n    ".join(literals),
         }
 
-# write CONFIG_H into includes/config.h
-open("includes/config.h", 'w').write(CONFIG_H)
-print("%s: file 'includes/config.h' correctly reconfigured" % sys.argv[0])
-
-# write CONFIG_C into src/config.c
-open("src/config.c", "w").write(CONFIG_C)
-print("%s: file 'src/config.c' correctly reconfigured" % sys.argv[0])
-
 
 ###############################################################################
 ### check dependencies
@@ -353,3 +345,23 @@ checklibs.append("libssl")
 
 if not check_lib_dependencies(*checklibs):
     abort("missing dependencies")
+
+###############################################################################
+### generate includes/config.h and src/config.c
+
+def update_file(filename, content):
+    if os.path.isfile(filename):
+        with open(filename) as file:
+            old_content = file.read()
+        action = "updated"
+    else:
+        old_content = ""
+        action = "created"
+    if old_content != content:
+        open(filename, 'w').write(content)
+        print("%s: %r correctly %s" % (sys.argv[0], filename, action))
+
+# write CONFIG_H into includes/config.h
+update_file("includes/config.h", CONFIG_H)
+# write CONFIG_C into src/config.c
+update_file("src/config.c", CONFIG_C)

--- a/tests/builder/makefile.sh
+++ b/tests/builder/makefile.sh
@@ -23,8 +23,7 @@ make distclean
 make distclean
 make
 make all
-test "$(make all | wc -l)" -eq "1"
-make all | grep -iq "nothing"
+test `make all | grep -i nothing | wc -l` -eq "1"
 
 
 #### test make re


### PR DESCRIPTION
the ./reconfigure script was writing config.c and config.h BEFORE
checking for dependencies.
Moved file write to the end of the script, if there has been no errors.
