### PR TITLE
docs(README): remove coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ BEURK
 =====
 [Getting Started] | [API Documentation] | [Contributing] | [TODO List]
 
-[![Travis Build](https://travis-ci.org/unix-thrust/beurk.svg?branch=master)](https://travis-ci.org/unix-thrust/beurk)
-[![Ready Issues](https://badge.waffle.io/unix-thrust/beurk.svg?label=Ready&title=Ready-Issues)](https://waffle.io/unix-thrust/beurk)
-[![Coverage Status](https://img.shields.io/coveralls/unix-thrust/beurk.svg)](https://coveralls.io/r/unix-thrust/beurk)
-[![Jenkins Build](http://ci.zgun-family.eu/job/BEURK/badge/icon)](http://ci.zgun-family.eu/job/BEURK/)
+[![Travis Build][Travis badge]](https://travis-ci.org/unix-thrust/beurk)
+[![Ready Issues][Waffle badge]](https://waffle.io/unix-thrust/beurk)
+[![Coverage Status][Cover badge]](https://coveralls.io/r/unix-thrust/beurk)
+[![Jenkins Build][Jenkins badge]](http://ci.zgun-family.eu/job/BEURK/)
 [![Join the chat at https://gitter.im/unix-thrust/beurk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/unix-thrust/beurk)
 
 **BEURK** is an userland [preload rootkit] for GNU/Linux, heavily focused
@@ -22,18 +22,20 @@ around anti-debugging and anti-detection.
 - Hide attacker files and directories
 - Realtime log cleanup (on [utmp/wtmp])
 - Anti process and login detection
+- Bypass unhide, lsof, ps, ldd, netstat analysis
+- Furtive PTY backdoor client
+
+### Upcoming features ###
 - [ptrace(2)] hooking for anti-debugging
 - [libpcap] hooking undermines local sniffers
-- Bypass unhide, lsof, ps, ldd, netstat analysis
 - PAM backdoor for *local privilege escalation*
-- Furtive PTY backdoor client
 
 ### Usage ###
 * **Compile**
 ```sh
     git clone https://github.com/unix-thrust/beurk.git
     cd beurk
-    ./build beurk.conf
+    make
 ```
 * **Install**
 ```sh
@@ -47,7 +49,7 @@ around anti-debugging and anti-detection.
 
 ### Dependencies ###
 
-The following packages are required in order to build BEURK:
+The following packages are not required in order to build BEURK at the moment:
 
 * **libpcap** - to avoid local sniffing
 * **libpam** - for local PAM backdoor
@@ -60,7 +62,7 @@ The following packages are required in order to build BEURK:
 
 -------------------------------------------------------------------------------
 
-[![Throughput Graph](https://graphs.waffle.io/unix-thrust/beurk/throughput.svg)](https://waffle.io/unix-thrust/beurk/metrics)
+[![Waffle metrics][Waffle metrics]](https://waffle.io/unix-thrust/beurk/metrics)
 
 * _**BEURK v 1.0 is in active development,**_
 _**please checkout current [development branch].**_
@@ -74,6 +76,12 @@ _**please checkout current [development branch].**_
 [API Documentation]: https://github.com/unix-thrust/beurk/wiki/API-Documentation
 [TODO List]: https://github.com/unix-thrust/beurk/blob/master/TODO.md
 [Contributing]: https://github.com/unix-thrust/beurk/blob/master/CONTRIBUTING.md
+
+[Travis badge]: https://travis-ci.org/unix-thrust/beurk.svg?branch=master
+[Waffle badge]: https://badge.waffle.io/unix-thrust/beurk.svg?label=Ready&title=Ready-Issues
+[Cover badge]: https://img.shields.io/coveralls/unix-thrust/beurk.svg
+[Jenkins badge]: http://ci.zgun-family.eu/job/BEURK/badge/icon
+[Waffle metrics]: https://graphs.waffle.io/unix-thrust/beurk/throughput.svg
 
 [preload rootkit]: http://volatility-labs.blogspot.fr/2012/09/movp-24-analyzing-jynx-rootkit-and.html
 [utmp/wtmp]: http://man7.org/linux/man-pages/man5/utmp.5.html

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ BEURK
 [![Travis Build](https://travis-ci.org/unix-thrust/beurk.svg?branch=master)](https://travis-ci.org/unix-thrust/beurk)
 [![Ready Issues](https://badge.waffle.io/unix-thrust/beurk.svg?label=Ready&title=Ready-Issues)](https://waffle.io/unix-thrust/beurk)
 [![Coverage Status](https://img.shields.io/coveralls/unix-thrust/beurk.svg)](https://coveralls.io/r/unix-thrust/beurk)
-[![Coverity Scan Build](https://img.shields.io/coverity/scan/4866.svg)](https://scan.coverity.com/projects/4866)
 [![Jenkins Build](http://ci.zgun-family.eu/job/BEURK/badge/icon)](http://ci.zgun-family.eu/job/BEURK/)
+[![Join the chat at https://gitter.im/unix-thrust/beurk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/unix-thrust/beurk)
 
 **BEURK** is an userland [preload rootkit] for GNU/Linux, heavily focused
 around anti-debugging and anti-detection.
@@ -15,7 +15,6 @@ around anti-debugging and anti-detection.
 >
 > *- The core team -*
 
-[![Join the chat at https://gitter.im/unix-thrust/beurk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/unix-thrust/beurk)
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
because of coverity.com free plan limitations, we prefer to use
coveralls for code coverage scans
