### PR TITLE
test(core): improve check_needed_unit_tests.sh

### DIFF
--- a/tests/core/check_needed_unit_tests.sh
+++ b/tests/core/check_needed_unit_tests.sh
@@ -23,15 +23,15 @@ function print_bad () {
 }
 
 errors=0
-while read filename; do
+for filename in $(find src/ -type f -name '*.c' -exec basename {} \;); do
     [[ "$EXCLUDE_FILES" =~ ' '$filename' ' ]] && continue
     if [ -f "$UNIT_TEST_DIR/$filename" ]; then
-        print_good "$filename unit-test is available. "
+        print_good "'$filename' unit-test is available. "
     else
-        print_bad "$filename unit-test is missing! "
+        print_bad "'$filename' unit-test is missing! "
         (( ++errors ))
     fi
-done < <(ls -1 src/*.c | cut -d'/' -f2)
+done
 
 [ $errors -ne 0 ] && exit 1
 exit 0


### PR DESCRIPTION
the test now also checks for hooks unit tests on
`tests/core/unit-tests/`, instead of just searching for
internal API functions
# NOTE

this makes the tests fail, because only are few tests are present in core/unit-tests for the moment
