### PR TITLE
fix(core): doesn't run functional test

### DIFF
--- a/utils/jenkins-tests.sh
+++ b/utils/jenkins-tests.sh
@@ -4,20 +4,12 @@ set -o pipefail
 
 # This script is used by jenkins.
 
-function help() {
-    echo "You need to define BEURK_VM_NAME and BEURK_VM_PORT environnements variables
-before running this script."
-    exit 1
-}
-
-[ -z "$BEURK_VM_NAME" ] && help
-[ -z "$BEURK_VM_PORT" ] && help
-
 # Go to the root of the project
 cd /home/vagrant/project/beurk
 
 # Disinfect the VM
-sudo kill `ps -ef | grep "python -m SimpleHTTPServer 3005" | grep -v "grep" | awk -F '  +' '{print $2}'`;
+BEURK_PID=`ps -ef | grep "python -m SimpleHTTPServer 3005" | grep -v "grep" | awk -F '  +' '{print $2}'`
+[ -z "$BEURK_PID" ] && sudo kill $BEURK_PID
 sudo make disinfect && sudo make distclean
 
 # Run the integration tests
@@ -26,9 +18,6 @@ sudo make disinfect && sudo make distclean
 # Infect the VM
 make re && sudo make infect
 nohup -- python -m SimpleHTTPServer 3005 &
-
-# Run the functional tests
-./utils/run-tests.sh tests/functional
 
 # Yeah!!!!
 exit 0


### PR DESCRIPTION
The functional test need to be run outside of the VM.
We only need to disinfect the VM before running integration test.
